### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "publisher": "ms-python",
     "engines": {
-        "vscode": "^1.19.0"
+        "vscode": "^1.26.0"
     },
     "license": "MIT",
     "displayName": "Anaconda Extension Pack",


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support `extensionPack` property

@brettcannon Please have this change before publishing the extension